### PR TITLE
io-500-score.sh errored out if no arguments specified

### DIFF
--- a/io-500-score.sh
+++ b/io-500-score.sh
@@ -5,16 +5,18 @@ set -euo pipefail   # give bash better error handling.
 export LC_NUMERIC=C  # prevents printf errors
 
 
-FILE="$1"
-if [[ "$FILE" == "" ]] ; then
+if [[ "$1" == "" ]] ; then
   echo "Synopsis: $0 <io500-standard-output>"
   exit 1
 fi
+
+FILE="$1"
 
 if [[ ! -r "$FILE" ]] ; then
   echo "Can't read from file \"$FILE\""
   exit 1
 fi
+
 
 TMP=$(mktemp)
 if [[ ! -r "$TMP" ]] ; then

--- a/io-500-score.sh
+++ b/io-500-score.sh
@@ -4,8 +4,7 @@ echo "Computing the IO-500 score (use io-500-validate.py to run extensive checks
 set -euo pipefail   # give bash better error handling.
 export LC_NUMERIC=C  # prevents printf errors
 
-
-if [[ "$1" == "" ]] ; then
+if [[ $# -eq 0 ]]; then
   echo "Synopsis: $0 <io500-standard-output>"
   exit 1
 fi


### PR DESCRIPTION
The error when no arguments were specified was a bash error: 

Computing the IO-500 score (use io-500-validate.py to run extensive checks!)
./io-500-score.sh: line 8: $1: unbound variable